### PR TITLE
Add blog with category/tag archives and starter posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,7 @@ author:
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"
-      url: "contatti"
+      url: "/contatti"
     - label: "Facebook"
       icon: "fab fa-fw fa-facebook-square"
       url: https://www.facebook.com/figliadimaestra.it/
@@ -195,7 +195,7 @@ sass:
 
 
 # Outputting
-permalink: /:categories/:title/
+permalink: /blog/:categories/:title/
 timezone: Europe/Rome
 
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,6 +6,8 @@ main:
     url: /micro-editing
   - title: "Creazione contenuti"
     url: /creazione-contenuti
+  - title: "Blog"
+    url: /blog/
   - title: "Chi sono"
     url: /chi-sono
   - title: "Contatti"

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -1,0 +1,6 @@
+---
+title: Blog
+permalink: /blog/
+layout: posts
+author_profile: true
+---

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Categorie"
+layout: categories
+permalink: /categories/
+author_profile: true
+---

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,0 +1,6 @@
+---
+title: "Tag"
+layout: tags
+permalink: /tags/
+author_profile: true
+---

--- a/_posts/2026-07-30-correzione-editing-beta-reading.md
+++ b/_posts/2026-07-30-correzione-editing-beta-reading.md
@@ -1,0 +1,39 @@
+---
+title: "Correzione di bozze, editing o beta reading? Facciamo chiarezza"
+categories:
+  - editing
+tags:
+  - editing
+  - beta-reading
+  - correzione-bozze
+excerpt: "Tre servizi diversi, tre momenti diversi della vita di un testo. Ecco quale ti serve davvero."
+---
+
+Una delle domande che mi sento fare più spesso è: "ma quindi a me cosa serve,
+la correzione di bozze o l'editing?". La risposta breve è: dipende da quanto è
+"finito" il tuo testo. Quella lunga è questo articolo.
+
+**La correzione di bozze** è l'ultimo passaggio, quello che si fa quando il
+testo è già definitivo nei contenuti e nella struttura. Si cercano refusi,
+errori di battitura, sviste ortografiche e sintattiche, incongruenze nella
+punteggiatura. Non si tocca la sostanza: non si riscrivono frasi, non si
+propongono tagli, non si discute la trama. È [chirurgia di precisione](/correzione-bozze),
+non un rifacimento.
+
+**Il micro-editing e il beta reading** entrano in gioco prima, quando il testo
+esiste già ma non è ancora nella sua forma migliore. Qui si guarda alla
+scorrevolezza della lettura, alle ripetizioni, al ritmo delle frasi, ai buchi
+di trama che l'autore non vede più perché li ha in testa da mesi. Non è un
+editing strutturale pesante (non si riscrive il romanzo), ma un lavoro di
+rifinitura e di segnalazione dei punti deboli, con suggerimenti concreti su
+[come risolverli](/micro-editing).
+
+**La creazione di contenuti**, infine, è tutta un'altra storia: non si parte
+da un testo esistente ma da un'idea, delle informazioni sparse o un brief, e si
+costruisce l'articolo da zero.
+
+Come regola pratica: se hai paura che ci sia un refuso, ti serve la correzione
+di bozze. Se hai paura che il lettore si perda o si annoi, ti serve il
+micro-editing. Se hai paura della pagina bianca, ti serve la creazione di
+contenuti. E se hai paura di tutte e tre le cose insieme, be': [scrivimi](/contatti),
+ne parliamo.

--- a/_posts/2026-07-30-duemila-articoli-dopo.md
+++ b/_posts/2026-07-30-duemila-articoli-dopo.md
@@ -1,0 +1,41 @@
+---
+title: "Cosa ho imparato correggendo (quasi) duemila articoli"
+categories:
+  - dietro-le-quinte
+tags:
+  - scrittura
+  - esperienza
+excerpt: "Tra il 2013 e il 2015 ho scritto un articolo al giorno per un sito di promozione culturale. Ecco cosa ne è rimasto."
+---
+
+Dal 2013 al 2015 ho pubblicato quotidianamente articoli per un sito di
+promozione culturale della Provincia di Lucca, mettendo insieme e sintetizzando
+informazioni, descrizioni e presentazioni che arrivavano dagli enti più vari:
+comuni, pro loco, associazioni, sagre di paese con la stessa foto della porchetta
+riciclata di anno in anno.
+
+Duemila articoli più tardi, quello che mi porto dietro non è un elenco di
+regole grammaticali (quelle, tutto sommato, si imparano in fretta), ma qualche
+convinzione più scomoda:
+
+**Nessun testo è "già chiaro" per chi lo legge per la prima volta.** Chi scrive
+conosce il contesto, le sigle, le sottintese; chi legge no. La sintesi vera non
+è tagliare parole, è colmare quello scarto senza che il lettore se ne accorga.
+
+**La lunghezza non è un pregio.** Un articolo lungo il doppio del necessario
+non è più completo, è solo più faticoso da leggere. Tagliare fa più bene al
+testo che aggiungere, quasi sempre.
+
+**Le ripetizioni si nascondono meglio di quanto si pensi.** Un aggettivo, una
+struttura di frase, un incipit: se piace a chi scrive, torna. E torna. E torna
+ancora, senza che l'autore se ne accorga, perché nella propria testa suona
+sempre nuovo.
+
+**Il tono conta quanto il contenuto.** Lo stesso identico fatto raccontato con
+entusiasmo o con distacco produce due articoli completamente diversi, ed è
+spesso questo, più della grammatica, a fare la differenza tra un testo che si
+legge volentieri e uno che si subisce.
+
+Sono le stesse cose che cerco ancora oggi quando [correggo una bozza](/correzione-bozze)
+o faccio [micro-editing](/micro-editing) su un manoscritto: non è mai solo
+questione di virgole.

--- a/_posts/2026-07-30-refusi-piu-comuni.md
+++ b/_posts/2026-07-30-refusi-piu-comuni.md
@@ -1,0 +1,43 @@
+---
+title: "I refusi più comuni (e come stanarli prima di me)"
+categories:
+  - correzione-bozze
+tags:
+  - ortografia
+  - refusi
+excerpt: "Qual è, qual'è, un po', po', perché no perchè: i sospetti abituali di ogni bozza."
+---
+
+Ogni volta che apro un manoscritto, un articolo o anche solo un messaggio troppo
+lungo per essere onesti, ci sono degli imputati che si ripresentano puntuali. Non
+sono errori di "chi non sa scrivere": sono trappole della lingua italiana, e
+cadono anche autori navigati.
+
+**"Qual è" senza apostrofo.** "Qual" davanti a vocale non prende mai l'apostrofo:
+si scrive *qual è*, non *qual'è*. La confusione nasce dal fatto che "qual"
+sembra tronco, ma non lo è: è la forma originaria dell'aggettivo, non
+un'elisione.
+
+**"Un po'" con l'apostrofo, non l'accento.** "Po'" è un troncamento di "poco",
+quindi ci vuole l'apostrofo (') e non l'accento (´). "Un pò" non esiste, per
+quanto la tastiera predittiva ve lo suggerisca con convinzione.
+
+**"Perché" con l'accento acuto, sempre.** Anche nella variante toscana urlata
+con la sigaretta in bocca. "Perchè" è un refuso talmente diffuso da sembrare
+quasi accettato, ma resta un errore.
+
+**Le doppie che vanno e vengono.** "Soqquadro" con due q, "beneficenza" con una
+sola c dopo la e, "cellulare" con due l: la memoria ortografica ci gioca brutti
+scherzi proprio sulle parole che usiamo più spesso, perché le battiamo a
+memoria muscolare senza più guardarle davvero.
+
+**Il punto e la virgola prima delle congiunzioni.** Non è un errore automatico
+mettere una virgola prima di "e", ma nella maggior parte dei casi in italiano
+non serve: se la frase regge senza, toglietela.
+
+La buona notizia è che, per gran parte di questi errori, basta rileggere ad
+alta voce e con calma per accorgersene. La cattiva notizia è che, sul proprio
+testo, l'occhio è clemente: dopo la decima rilettura si legge quello che si
+crede di aver scritto, non quello che c'è davvero sulla pagina. Ed è esattamente
+per questo che serve [un secondo paio d'occhi](/correzione-bozze) — possibilmente
+i miei.


### PR DESCRIPTION
## Summary
- Adds `_posts` support with a `/blog/` listing page plus `/categories/` and `/tags/` archive pages, using the theme's existing `posts`, `categories`, and `tags` layouts, and adds a "Blog" nav entry.
- Namespaces post permalinks under `/blog/:categories/:title/` so category slugs can never collide with existing service page permalinks (found and fixed a real collision during testing, where a post categorized `correzione-bozze` silently ate the `/correzione-bozze` service page's output).
- Fixes a pre-existing broken relative `contatti` link in the author sidebar (`_config.yml`) that only worked by accident while every page lived at the site root; now nested pages like `/blog/` and post pages resolve it correctly.
- Adds 3 starter posts in Italian matching Anna's existing tone: common Italian spelling/punctuation mistakes, proofreading vs. editing vs. beta reading vs. content creation, and a behind-the-scenes piece on her ~2000-article stint.

## Test plan
- [x] `bundle exec jekyll build` succeeds
- [x] `bundle exec htmlproofer ./_site --ignore-missing-alt --disable-external` passes
- [x] Verified `/blog/`, `/categories/`, `/tags/` render and post URLs live under `/blog/<category>/<title>/` without colliding with existing service pages